### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "billerickson/wp-cli-plugin-install-missing",
 	"description": "Install any plugins that are active but missing.",
+	"type": "wp-cli-package",
 	"homepage": "https://github.com/billerickson/wp-cli-plugin-install-missing",
 	"license": "MIT",
 	"require": {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
